### PR TITLE
Queue activity bridge

### DIFF
--- a/library/src/main/java/com/queue_it/androidsdk/QueueITEngine.java
+++ b/library/src/main/java/com/queue_it/androidsdk/QueueITEngine.java
@@ -9,6 +9,7 @@ import android.net.ConnectivityManager;
 import android.net.NetworkInfo;
 import android.os.Handler;
 import android.provider.Settings;
+import android.support.annotation.Nullable;
 import android.support.v4.content.LocalBroadcastManager;
 import android.text.TextUtils;
 import android.util.Log;
@@ -308,5 +309,27 @@ public class QueueITEngine {
     private String getSdkVersion()
     {
         return "Android-" + BuildConfig.VERSION_NAME;
+    }
+
+    public void justOpenQueue() {
+        if (hasCacheAndData()) {
+            _activity.startActivity(
+                    new Intent(_activity, QueueActivity.class)
+                            .putExtra("queueUrl", _queueCache.getQueueUrl())
+                            .putExtra("targetUrl", _queueCache.getTargetUrl())
+            );
+            return;
+        }
+        alertCacheException();
+    }
+
+    private boolean hasCacheAndData() {
+        return _queueCache != null
+                && _queueCache.getQueueUrl() != null && !_queueCache.getQueueUrl().isEmpty()
+                && _queueCache.getTargetUrl() != null && !_queueCache.getTargetUrl().isEmpty();
+    }
+
+    private void alertCacheException() {
+        throw new IllegalArgumentException(_activity.getString(R.string.open_activity_with_no_cache_error_message));
     }
 }

--- a/library/src/main/res/values/strings.xml
+++ b/library/src/main/res/values/strings.xml
@@ -1,4 +1,5 @@
 <resources>
     <string name="app_name">Android SDK</string>
     <string name="notification_error_ssl_cert_invalid">Invalid SSL certificate. Do you want to continue?</string>
+    <string name="open_activity_with_no_cache_error_message">cache did not find, are you sure you have already ran an engine?</string>
 </resources>


### PR DESCRIPTION
This PR implements a way to start queue activity without running all engine flow again, just a doubt about it, can cache queue url and target url be empty?