### PR TITLE
Use HTTPS for API Url instead of HTTP

### DIFF
--- a/library/src/main/java/com/queue_it/androidsdk/QueueService.java
+++ b/library/src/main/java/com/queue_it/androidsdk/QueueService.java
@@ -41,9 +41,9 @@ public class QueueService {
     private String getApiUrl()
     {
         if (IsTest) {
-            return "http://%s.test.queue-it.net/api/queue/%s/%s/appenqueue";
+            return "https://%s.test.queue-it.net/api/queue/%s/%s/appenqueue";
         } else {
-            return "http://%s.queue-it.net/api/queue/%s/%s/appenqueue";
+            return "https://%s.queue-it.net/api/queue/%s/%s/appenqueue";
         }
     }
 


### PR DESCRIPTION
Starting with Android 9.0 (API level 28), cleartext support is disabled by default.
https://developer.android.com/training/articles/security-config#CleartextTrafficPermitted