### PR TITLE
[Bug] Fix UriOverrider::isTargetUri with different paths

### DIFF
--- a/library/src/main/java/com/queue_it/androidsdk/UriOverrider.java
+++ b/library/src/main/java/com/queue_it/androidsdk/UriOverrider.java
@@ -50,7 +50,7 @@ public class UriOverrider implements IUriOverrider {
         String destinationPath = destinationUri.getPath();
 
         String targetHost = target.getHost();
-        String targetPath = destinationUri.getPath();
+        String targetPath = target.getPath();
 
         return destinationHost.equalsIgnoreCase(targetHost)
                 && destinationPath.equals(targetPath);

--- a/library/src/test/java/com/queue_it/androidsdk/UriOverriderTest.java
+++ b/library/src/test/java/com/queue_it/androidsdk/UriOverriderTest.java
@@ -231,6 +231,44 @@ public class UriOverriderTest {
     }
 
     @Test
+    public void givenUserIsNavigatingToOtherPathThenLoadShouldBeCancelledAndIntentShouldBeStarted() {
+        UriOverrider testObj = new UriOverrider();
+        testObj.setQueue(Uri.parse("https://useraccount.queue-it.net/app/enqueue"));
+        testObj.setTarget(Uri.parse("https://www.qoqa.ch/"));
+        WebView webView = getMockedWebview();
+        final AtomicBoolean queuePassed = new AtomicBoolean(false);
+        ArgumentCaptor<Intent> argument = ArgumentCaptor.forClass(Intent.class);
+        String otherPage = "https://www.qoqa.ch/concept";
+
+        boolean loadCancelled = testObj.handleNavigationRequest(otherPage, webView, new UriOverrideWrapper() {
+            @Override
+            protected void onQueueUrlChange(String uri) {
+                System.out.print(uri);
+            }
+
+            @Override
+            protected void onPassed(String queueItToken) {
+                queuePassed.set(true);
+            }
+
+            @Override
+            protected void onCloseClicked() {
+
+            }
+
+            @Override
+            protected void onSessionRestart() {
+
+            }
+        });
+
+        assertTrue(loadCancelled);
+        assertFalse(queuePassed.get());
+
+        verify(webView.getContext()).startActivity(argument.capture());
+    }
+
+    @Test
     public void givenAppUserIsRedirectedToDeepLinkThenLoadShouldBeCancelled() {
         UriOverrider testObj = new UriOverrider();
         testObj.setQueue(Uri.parse("qapp://enqueue"));


### PR DESCRIPTION
We have a use case where the alternate page is on the same domain as the target page.
I think it's just a typo, but the code is not properly checking the path. The alternate URL is detected as the target URL.