### PR TITLE
[Doc] Remove manifest information

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,16 +145,3 @@ queueITWaitingRoomView.showQueue(_queuePassedInfo.getQueueUrl(), _queuePassedInf
 ```
 ## Mobile SDK Integration with proteced API (Queue-it connector on server side): 
 If your application is using an API that's protected by a Queue-it connector (KnownUser) you can check out [this documentation](https://github.com/queueit/android-webui-sdk/blob/master/documentation/protected_apis.md).
-
-## Required permissions
-
-```xml
-<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
-<uses-permission android:name="android.permission.INTERNET"/>
-```
-
-## Activities to include in your manifest
-
-```xml
-<activity android:name="com.queue_it.androidsdk.QueueActivity" />
-```


### PR DESCRIPTION
`library/src/main/AndroidManifest.xml` will be merged automatically when a project include this library.

Android documentation about the merging => https://developer.android.com/build/manage-manifests

> Your APK or Android App Bundle file can contain just one AndroidManifest.xml file, but your Android Studio project may contain several manifest files provided by the main source set, build variants, and imported libraries. When building your app, the Gradle build merges all manifest files into a single manifest file that's packaged into your app.