### PR TITLE
Set WebView background color to transparent in disposeWebview

### DIFF
--- a/library/src/main/java/com/queue_it/androidsdk/QueueActivityBase.java
+++ b/library/src/main/java/com/queue_it/androidsdk/QueueActivityBase.java
@@ -220,6 +220,7 @@ public class QueueActivityBase {
     }
 
     private void disposeWebview(WebView webView) {
+        webView.setBackgroundColor(Color.TRANSPARENT);
         webView.loadUrl("about:blank");
         _context.finish();
     }


### PR DESCRIPTION
Updated the disposeWebview method to set the background color to transparent before loading about:blank to prevent a white flash when closing the WebView

**Before:**
<img width="1915" height="1030" alt="image" src="https://github.com/user-attachments/assets/733a6b14-7755-4d78-8abe-8dadad67008e" />

**After:** 
<img width="1904" height="1021" alt="image" src="https://github.com/user-attachments/assets/6627158b-93a9-4f96-83a4-29d395d0a9bf" />

As shown in the AFTER image, about:blank now displays the same background color as the app while the WebView is closing, preventing the white flashing effect during the transition.